### PR TITLE
Fix resource leak in the winit example

### DIFF
--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -1,16 +1,28 @@
 use std::{ptr, time::Instant};
 
 use imgui::{FontConfig, FontSource};
-use imgui_winit_support::{HiDpiMode, WinitPlatform, winit::{window::WindowBuilder, event::{Event, WindowEvent}, event_loop::{EventLoop, ControlFlow}, dpi::LogicalSize}};
+use imgui_dx9_renderer::Renderer;
+use imgui_winit_support::{
+    winit::{
+        dpi::LogicalSize,
+        event::{Event, WindowEvent},
+        event_loop::{ControlFlow, EventLoop},
+        window::WindowBuilder,
+    },
+    HiDpiMode, WinitPlatform,
+};
 use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
 use winapi::shared::{d3d9::*, d3d9caps::*, d3d9types::*, windef::HWND};
+use wio::com::ComPtr;
 
 const WINDOW_WIDTH: f64 = 760.0;
 const WINDOW_HEIGHT: f64 = 760.0;
 
-unsafe fn set_up_dx_context(hwnd: HWND) -> (LPDIRECT3D9, LPDIRECT3DDEVICE9) {
+unsafe fn set_up_dx_context(hwnd: HWND) -> (ComPtr<IDirect3D9>, ComPtr<IDirect3DDevice9>) {
     let d9 = Direct3DCreate9(D3D_SDK_VERSION);
     assert!(!d9.is_null(), "Direct3DCreate9 failed");
+    let d9 = ComPtr::from_raw(d9);
+
     let mut present_params = D3DPRESENT_PARAMETERS {
         BackBufferCount: 1,
         MultiSampleType: D3DMULTISAMPLE_NONE,
@@ -37,6 +49,8 @@ unsafe fn set_up_dx_context(hwnd: HWND) -> (LPDIRECT3D9, LPDIRECT3DDEVICE9) {
         &mut device,
     );
     assert!(r >= 0, "CreateDevice failed");
+    let device = ComPtr::from_raw(device);
+
     (d9, device)
 }
 
@@ -53,9 +67,12 @@ fn main() {
     } else {
         unreachable!()
     };
+
     let (_d9, device) = unsafe { set_up_dx_context(hwnd as _) };
+
     let mut imgui = imgui::Context::create();
     imgui.set_ini_filename(None);
+
     let mut platform = WinitPlatform::init(&mut imgui);
     platform.attach_window(imgui.io_mut(), &window, HiDpiMode::Rounded);
 
@@ -66,12 +83,9 @@ fn main() {
     }]);
     imgui.io_mut().font_global_scale = (1.0 / hidpi_factor) as f32;
 
-    let mut renderer = unsafe {
-        imgui_dx9_renderer::Renderer::new(&mut imgui, wio::com::ComPtr::from_raw(device)).unwrap()
-    };
+    let mut renderer = unsafe { Renderer::new(&mut imgui, device.clone()).unwrap() };
 
     let mut last_frame = Instant::now();
-
     event_loop.run(move |event, _, control_flow| match event {
         Event::NewEvents(_) => {
             let now = Instant::now();
@@ -85,12 +99,14 @@ fn main() {
         },
         Event::RedrawRequested(_) => {
             unsafe {
-                (*device).Clear(0, ptr::null_mut(), D3DCLEAR_TARGET, 0xFFAA_AAAA, 1.0, 0);
-                (*device).BeginScene();
+                device.Clear(0, ptr::null_mut(), D3DCLEAR_TARGET, 0xFFAA_AAAA, 1.0, 0);
+                device.BeginScene();
             }
 
             let ui = imgui.new_frame();
-            ui.window("Hello world")
+
+            ui.show_demo_window(&mut true);
+            ui.window("Hello world") //
                 .size([300.0, 100.0], imgui::Condition::FirstUseEver)
                 .build(|| {
                     ui.text("Hello world!");
@@ -99,24 +115,18 @@ fn main() {
                     let mouse_pos = ui.io().mouse_pos;
                     ui.text(format!("Mouse Position: ({:.1},{:.1})", mouse_pos[0], mouse_pos[1]));
                 });
-            ui.show_demo_window(&mut true);
+
             platform.prepare_render(ui, &window);
             renderer.render(imgui.render()).unwrap();
+
             unsafe {
-                (*device).EndScene();
-                (*device).Present(
-                    ptr::null_mut(),
-                    ptr::null_mut(),
-                    ptr::null_mut(),
-                    ptr::null_mut(),
-                );
+                device.EndScene();
+                device.Present(ptr::null_mut(), ptr::null_mut(), ptr::null_mut(), ptr::null_mut());
             }
         },
         Event::WindowEvent { event: WindowEvent::CloseRequested, .. } => {
             *control_flow = ControlFlow::Exit
         },
-        event => {
-            platform.handle_event(imgui.io_mut(), &window, &event);
-        },
+        event => platform.handle_event(imgui.io_mut(), &window, &event),
     });
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,8 @@ use winapi::shared::d3d9::{
     IDirect3DTexture9, IDirect3DVertexBuffer9,
 };
 use winapi::shared::d3d9types::*;
-use winapi::shared::winerror::{DXGI_ERROR_INVALID_CALL, HRESULT, S_OK};
 use winapi::shared::windef::RECT;
+use winapi::shared::winerror::{DXGI_ERROR_INVALID_CALL, HRESULT, S_OK};
 use winapi::Interface;
 use wio::com::ComPtr;
 
@@ -100,7 +100,10 @@ impl Renderer {
     /// `device` must be a valid [`IDirect3DDevice9`] pointer.
     ///
     /// [`IDirect3DDevice9`]: https://docs.rs/winapi/0.3/x86_64-pc-windows-msvc/winapi/shared/d3d9/struct.IDirect3DDevice9.html
-    pub unsafe fn new_raw(im_ctx: &mut imgui::Context, device: *mut IDirect3DDevice9) -> Result<Self> {
+    pub unsafe fn new_raw(
+        im_ctx: &mut imgui::Context,
+        device: *mut IDirect3DDevice9,
+    ) -> Result<Self> {
         let device = ComPtr::from_raw(device);
         device.AddRef();
         Self::new(im_ctx, device)
@@ -273,7 +276,7 @@ impl Renderer {
             0,
             (vtx_count * mem::size_of::<CustomVertex>()) as u32,
             &mut vtx_dst as *mut _ as _,
-            D3DLOCK_DISCARD as u32,
+            D3DLOCK_DISCARD,
         );
 
         match hresult(ib.Lock(
@@ -319,12 +322,7 @@ impl Renderer {
         }
         vb.Unlock();
         ib.Unlock();
-        self.device.SetStreamSource(
-            0,
-            vb,
-            0,
-            mem::size_of::<CustomVertex>() as u32,
-        );
+        self.device.SetStreamSource(0, vb, 0, mem::size_of::<CustomVertex>() as u32);
         self.device.SetIndices(ib);
         self.device.SetFVF(D3DFVF_CUSTOMVERTEX);
         Ok(())


### PR DESCRIPTION
The example as-is never calls .Release() on the IDirect3D9 it allocates. This isn't really a problem since it'll be freed on process exit anyway, but since it's an example we want to do things properly.
